### PR TITLE
Session refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         maven { url 'https://developer.huawei.com/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 're.notifica.gradle:notificare-services:1.0.1'
         classpath 'com.google.gms:google-services:4.3.10'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 13 15:06:31 CEST 2020
+#Wed Jun 01 15:03:56 WEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/notificare/src/main/AndroidManifest.xml
+++ b/notificare/src/main/AndroidManifest.xml
@@ -11,6 +11,12 @@
             android:authorities="${applicationId}.NotificareConfigurationProvider"
             android:exported="false" />
 
+        <!-- Provider to auto configure the session module -->
+        <provider
+            android:name="re.notifica.NotificareSessionConfigurationProvider"
+            android:authorities="${applicationId}.NotificareSessionConfigurationProvider"
+            android:exported="false" />
+
         <!-- Receiver for locale and timezone changes -->
         <receiver
             android:name="re.notifica.NotificareSystemIntentReceiver"

--- a/notificare/src/main/java/re/notifica/NotificareEventsModule.kt
+++ b/notificare/src/main/java/re/notifica/NotificareEventsModule.kt
@@ -4,29 +4,9 @@ import re.notifica.models.NotificareEventData
 
 public interface NotificareEventsModule {
 
-    public suspend fun logApplicationInstall()
-
-    public fun logApplicationInstall(callback: NotificareCallback<Unit>)
-
-    public suspend fun logApplicationRegistration()
-
-    public fun logApplicationRegistration(callback: NotificareCallback<Unit>)
-
-    public suspend fun logApplicationUpgrade()
-
-    public fun logApplicationUpgrade(callback: NotificareCallback<Unit>)
-
-    public suspend fun logApplicationOpen()
-
-    public fun logApplicationOpen(callback: NotificareCallback<Unit>)
-
     public suspend fun logApplicationException(throwable: Throwable)
 
     public fun logApplicationException(throwable: Throwable, callback: NotificareCallback<Unit>)
-
-    public suspend fun logApplicationClose(sessionLength: Double)
-
-    public fun logApplicationClose(sessionLength: Double, callback: NotificareCallback<Unit>)
 
     public suspend fun logNotificationOpen(id: String)
 
@@ -40,5 +20,10 @@ public interface NotificareEventsModule {
 public interface NotificareInternalEventsModule {
 
     @InternalNotificareApi
-    public suspend fun log(event: String, data: NotificareEventData? = null, notificationId: String? = null)
+    public suspend fun log(
+        event: String,
+        data: NotificareEventData? = null,
+        sessionId: String? = null,
+        notificationId: String? = null,
+    )
 }

--- a/notificare/src/main/java/re/notifica/NotificareIntentReceiver.kt
+++ b/notificare/src/main/java/re/notifica/NotificareIntentReceiver.kt
@@ -33,7 +33,7 @@ public open class NotificareIntentReceiver : BroadcastReceiver() {
     }
 
     protected open fun onUnlaunched(context: Context) {
-        NotificareLogger.info("Notificare has finished un-launching, please override onReady if you want to receive these intents.")
+        NotificareLogger.info("Notificare has finished un-launching, please override onUnlaunched if you want to receive these intents.")
     }
 
     protected open fun onDeviceRegistered(context: Context, device: NotificareDevice) {

--- a/notificare/src/main/java/re/notifica/NotificareSessionConfigurationProvider.kt
+++ b/notificare/src/main/java/re/notifica/NotificareSessionConfigurationProvider.kt
@@ -1,0 +1,48 @@
+package re.notifica
+
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import re.notifica.internal.NotificareLogger
+import re.notifica.ktx.session
+
+/**
+ * Auto configuration during application startup.
+ */
+internal class NotificareSessionConfigurationProvider : ContentProvider() {
+    /**
+     * Called before [android.app.Application.onCreate].
+     */
+    override fun onCreate(): Boolean {
+        val context = context ?: throw IllegalStateException("Cannot find context from the provider.")
+        val application = context.applicationContext as Application
+
+        NotificareLogger.debug("Configuring session lifecycle listeners.")
+        Notificare.session().setupLifecycleListeners(application)
+
+        return true
+    }
+
+    override fun query(
+        p0: Uri,
+        p1: Array<out String>?,
+        p2: String?,
+        p3: Array<out String>?,
+        p4: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+}

--- a/notificare/src/main/java/re/notifica/internal/NotificareModule.kt
+++ b/notificare/src/main/java/re/notifica/internal/NotificareModule.kt
@@ -18,9 +18,9 @@ public abstract class NotificareModule {
     @InternalNotificareApi
     public enum class Module(private val fqn: String) {
         // Default modules
-        DEVICE(fqn = "re.notifica.internal.modules.NotificareDeviceModuleImpl"),
         EVENTS(fqn = "re.notifica.internal.modules.NotificareEventsModuleImpl"),
         SESSION(fqn = "re.notifica.internal.modules.NotificareSessionModuleImpl"),
+        DEVICE(fqn = "re.notifica.internal.modules.NotificareDeviceModuleImpl"),
         CRASH_REPORTER(fqn = "re.notifica.internal.modules.NotificareCrashReporterModuleImpl"),
 
         // Peer modules

--- a/notificare/src/main/java/re/notifica/internal/modules/NotificareDeviceModuleImpl.kt
+++ b/notificare/src/main/java/re/notifica/internal/modules/NotificareDeviceModuleImpl.kt
@@ -12,7 +12,7 @@ import re.notifica.internal.common.toHex
 import re.notifica.internal.ktx.toCallbackFunction
 import re.notifica.internal.network.push.*
 import re.notifica.internal.network.request.NotificareRequest
-import re.notifica.ktx.events
+import re.notifica.ktx.eventsImplementation
 import re.notifica.models.NotificareDevice
 import re.notifica.models.NotificareDoNotDisturb
 import re.notifica.models.NotificareTransport
@@ -31,7 +31,7 @@ internal object NotificareDeviceModuleImpl : NotificareModule(), NotificareDevic
             if (device.appVersion != NotificareUtils.applicationVersion) {
                 // It's not the same version, let's log it as an upgrade.
                 NotificareLogger.debug("New version detected")
-                Notificare.events().logApplicationUpgrade()
+                Notificare.eventsImplementation().logApplicationUpgrade()
             }
 
             register(
@@ -50,8 +50,8 @@ internal object NotificareDeviceModuleImpl : NotificareModule(), NotificareDevic
                 registerTemporary()
 
                 // We will log the Install & Registration events here since this will execute only one time at the start.
-                Notificare.events().logApplicationInstall()
-                Notificare.events().logApplicationRegistration()
+                Notificare.eventsImplementation().logApplicationInstall()
+                Notificare.eventsImplementation().logApplicationRegistration()
             } catch (e: Exception) {
                 NotificareLogger.warning("Failed to register temporary device.", e)
                 throw e

--- a/notificare/src/main/java/re/notifica/internal/modules/NotificareEventsModuleImpl.kt
+++ b/notificare/src/main/java/re/notifica/internal/modules/NotificareEventsModuleImpl.kt
@@ -1,7 +1,8 @@
 package re.notifica.internal.modules
 
 import androidx.work.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import re.notifica.Notificare
 import re.notifica.NotificareCallback
 import re.notifica.NotificareEventsModule
@@ -48,51 +49,12 @@ internal object NotificareEventsModuleImpl : NotificareModule(), NotificareEvent
 
     // region Notificare Events Module
 
-    override suspend fun logApplicationInstall() {
-        log(EVENT_APPLICATION_INSTALL)
-    }
-
-    override fun logApplicationInstall(callback: NotificareCallback<Unit>): Unit =
-        toCallbackFunction(::logApplicationInstall)(callback)
-
-    override suspend fun logApplicationRegistration() {
-        log(EVENT_APPLICATION_REGISTRATION)
-    }
-
-    override fun logApplicationRegistration(callback: NotificareCallback<Unit>): Unit =
-        toCallbackFunction(::logApplicationRegistration)(callback)
-
-    override suspend fun logApplicationUpgrade() {
-        log(EVENT_APPLICATION_UPGRADE)
-    }
-
-    override fun logApplicationUpgrade(callback: NotificareCallback<Unit>): Unit =
-        toCallbackFunction(::logApplicationUpgrade)(callback)
-
-    override suspend fun logApplicationOpen() {
-        log(EVENT_APPLICATION_OPEN)
-    }
-
-    override fun logApplicationOpen(callback: NotificareCallback<Unit>): Unit =
-        toCallbackFunction(::logApplicationOpen)(callback)
-
     override suspend fun logApplicationException(throwable: Throwable) {
         log(throwable.toEvent())
     }
 
     override fun logApplicationException(throwable: Throwable, callback: NotificareCallback<Unit>): Unit =
         toCallbackFunction(::logApplicationException)(throwable, callback)
-
-    override suspend fun logApplicationClose(sessionLength: Double) {
-        log(
-            EVENT_APPLICATION_CLOSE, mapOf(
-                "length" to sessionLength.toString()
-            )
-        )
-    }
-
-    override fun logApplicationClose(sessionLength: Double, callback: NotificareCallback<Unit>): Unit =
-        toCallbackFunction(::logApplicationClose)(sessionLength, callback)
 
     override suspend fun logNotificationOpen(id: String) {
         log(
@@ -116,13 +78,13 @@ internal object NotificareEventsModuleImpl : NotificareModule(), NotificareEvent
 
     // region Notificare Internal Events Module
 
-    override suspend fun log(event: String, data: NotificareEventData?, notificationId: String?) {
+    override suspend fun log(event: String, data: NotificareEventData?, sessionId: String?, notificationId: String?) {
         log(
             NotificareEvent(
                 type = event,
                 timestamp = System.currentTimeMillis(),
                 deviceId = Notificare.device().currentDevice?.id,
-                sessionId = Notificare.session().sessionId,
+                sessionId = sessionId ?: Notificare.session().sessionId,
                 notificationId = notificationId,
                 userId = Notificare.device().currentDevice?.userId,
                 data = data
@@ -131,6 +93,33 @@ internal object NotificareEventsModuleImpl : NotificareModule(), NotificareEvent
     }
 
     // endregion
+
+    internal suspend fun logApplicationInstall() {
+        log(EVENT_APPLICATION_INSTALL)
+    }
+
+    internal suspend fun logApplicationRegistration() {
+        log(EVENT_APPLICATION_REGISTRATION)
+    }
+
+    internal suspend fun logApplicationUpgrade() {
+        log(EVENT_APPLICATION_UPGRADE)
+    }
+
+    internal suspend fun logApplicationOpen(sessionId: String) {
+        log(
+            event = EVENT_APPLICATION_OPEN,
+            sessionId = sessionId
+        )
+    }
+
+    internal suspend fun logApplicationClose(sessionId: String, sessionLength: Double) {
+        log(
+            event = EVENT_APPLICATION_CLOSE,
+            data = mapOf("length" to sessionLength.toString()),
+            sessionId = sessionId,
+        )
+    }
 
     internal suspend fun log(event: NotificareEvent): Unit = withContext(Dispatchers.IO) {
         if (!Notificare.isConfigured) {

--- a/notificare/src/main/java/re/notifica/internal/modules/NotificareEventsModuleImpl.kt
+++ b/notificare/src/main/java/re/notifica/internal/modules/NotificareEventsModuleImpl.kt
@@ -149,9 +149,14 @@ internal object NotificareEventsModuleImpl : NotificareModule(), NotificareEvent
 
             if (!discardableEvents.contains(event.type) && e.recoverable) {
                 NotificareLogger.info("Queuing event to be sent whenever possible.")
+
                 Notificare.database.events().insert(event.toEntity())
                 scheduleUploadWorker()
+
+                return@withContext
             }
+
+            throw e
         }
     }
 


### PR DESCRIPTION
The session should be started and logged during the launch flow.

The application close event should receive the session ID in the method parameters to prevent misuse of the current ID.

The session module should skip the unified configuration flow, and use a configuration provider to attach the lifecycle listeners.

The session should be stopped when Notificare is un-launched.