### PR TITLE
Refactor NotificarePushService

### DIFF
--- a/notificare-push/src/main/AndroidManifest.xml
+++ b/notificare-push/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
         <!-- Allow incoming push messages to be handled by the app -->
         <service
-            android:name="re.notifica.push.NotificarePushService"
+            android:name="re.notifica.push.NotificareFirebaseMessagingService"
             android:exported="false"
             android:label="Notificare Push Service">
             <intent-filter>

--- a/notificare-push/src/main/java/re/notifica/push/NotificareFirebaseMessagingService.kt
+++ b/notificare-push/src/main/java/re/notifica/push/NotificareFirebaseMessagingService.kt
@@ -12,7 +12,7 @@ import re.notifica.push.ktx.push
 import re.notifica.push.ktx.pushInternal
 import re.notifica.push.models.NotificareTransport
 
-public open class NotificarePushService : FirebaseMessagingService() {
+public open class NotificareFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         Notificare.pushInternal().handleNewToken(NotificareTransport.GCM, token)


### PR DESCRIPTION
BREAKING CHANGE: rename usages of NotificarePushService to NotificareFirebaseMessagingService
